### PR TITLE
Automate Start/Stop on ContainerFixture when using `[ClassDataSource<>]`

### DIFF
--- a/test/Kurrent.Replicator.Tests/ChaserCheckpointSeedingTests.cs
+++ b/test/Kurrent.Replicator.Tests/ChaserCheckpointSeedingTests.cs
@@ -29,12 +29,6 @@ public class ChaserCheckpointSeedingTests {
             .ForContext<ChaserCheckpointSeedingTests>();
     }
 
-    [Before(Test)]
-    public async Task Start() => await _fixture.StartContainers();
-
-    [After(Test)]
-    public async Task Stop() => await _fixture.StopContainers();
-
     [Test]
     public async Task Verify() {
         var v5DataPath = _fixture.V5DataPath;

--- a/test/Kurrent.Replicator.Tests/CustomPartitionerTests.cs
+++ b/test/Kurrent.Replicator.Tests/CustomPartitionerTests.cs
@@ -31,12 +31,6 @@ public class ValuePartitionerTests {
             .ForContext<ValuePartitionerTests>();
     }
 
-    [Before(Test)]
-    public async Task Start() => await _fixture.StartContainers();
-
-    [After(Test)]
-    public async Task Stop() => await _fixture.StopContainers();
-
     [Test]
     public async Task ShouldKeepOrderWithinPartition() {
         var             checkpointStore = new CheckpointStore();

--- a/test/Kurrent.Replicator.Tests/Fixtures/ContainerFixture.cs
+++ b/test/Kurrent.Replicator.Tests/Fixtures/ContainerFixture.cs
@@ -3,15 +3,16 @@ using DotNet.Testcontainers.Containers;
 using EventStore.Client;
 using EventStore.ClientAPI;
 using Testcontainers.EventStoreDb;
+using TUnit.Core.Interfaces;
 
 namespace Kurrent.Replicator.Tests.Fixtures;
 
-public class ContainerFixture {
+public class ContainerFixture : IAsyncInitializer, IAsyncDisposable {
     EventStoreDbContainer _kurrentDbContainer;
     IContainer            _eventStoreContainer;
     public DirectoryInfo  V5DataPath { get; private set; }
 
-    public async Task StartContainers() {
+    public async Task InitializeAsync() {
         V5DataPath           = Directory.CreateTempSubdirectory();
         _kurrentDbContainer  = BuildV23Container();
         _eventStoreContainer = BuildV5Container(V5DataPath);
@@ -21,7 +22,7 @@ public class ContainerFixture {
         await Task.Delay(TimeSpan.FromSeconds(2)); // give it some time to spin up
     }
 
-    public async Task StopContainers() {
+    public async ValueTask DisposeAsync() {
         await Task.WhenAll(_kurrentDbContainer.StopAsync(), _eventStoreContainer.StopAsync());
         await _eventStoreContainer.DisposeAsync();
         await _kurrentDbContainer.DisposeAsync();


### PR DESCRIPTION
Heya - Noticed you switched to TUnit 😄 

When you're using `[ClassDataSource<>]` you can put the set up and tear down logic for it inside it by implementing the interfaces `IAsyncInitializer` and `IAsyncDisposable`. TUnit will automatically call the appropriate methods before passing to your tests, so you don't need to call them manually in each test class with a `[Before(Test)]` hook.

Should just make things slightly cleaner and easier to maintain for you 😄 